### PR TITLE
(SIMP-4680) Migrate to simp_banners

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,5 +3,6 @@ fixtures:
   repositories:
     stdlib:   "https://github.com/simp/puppetlabs-stdlib.git"
     simplib:  "https://github.com/simp/pupmod-simp-simplib.git"
+    simp_banners: "https://github.com/simp/pupmod-simp-simp_banners"
   symlinks:
     issue: "#{source_dir}"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,97 +1,275 @@
-#
 ---
-puppet-syntax: 
-  stage: test
-  tags: 
-    - docker
-  image: ruby:2.1
-  script: 
-    - bundle install
-    - bundle exec rake syntax
-puppet-lint: 
-  stage: test
-  tags: 
-    - docker
-  image: ruby:2.1
-  script: 
-    - bundle install
-    - bundle exec rake lint
-puppet-metadata: 
-  stage: test
-  tags: 
-    - docker
-  image: ruby:2.1
-  script: 
-    - bundle install
-    - bundle exec rake metadata
-unit-test-ruby-2.1:
-  stage: test
-  tags: 
-    - docker
-  image: ruby:2.1
-  script: 
-    - bundle install
-    - bundle exec rake spec
-unit-test-ruby-2.2:
-  stage: test
-  tags: 
-    - docker
-  image: ruby:2.2
-  allow_failure: true
-  script: 
-    - bundle install
-    - bundle exec rake spec
-unit-test-ruby-2.3:
-  stage: test
-  tags: 
-    - docker
-  image: ruby:2.3
-  allow_failure: true
-  script: 
-    - bundle install
-    - bundle exec rake spec
 
-# For PE LTS Support
-# See: https://puppet.com/misc/puppet-enterprise-lifecycle
-puppet4.7-syntax: 
-  stage: test
-  tags: 
-    - docker
-  image: ruby:2.1
-  script: 
-    - PUPPET_VERSION=4.7 bundle install
-    - PUPPET_VERSION=4.7 bundle exec rake syntax
-unit-test-puppet4.7-ruby-2.1:
-  stage: test
-  tags: 
-    - docker
-  image: ruby:2.1
-  script: 
-    - PUPPET_VERSION=4.7 bundle install
-    - PUPPET_VERSION=4.7 bundle exec rake spec
-unit-test-puppet4.7-ruby-2.2:
-  stage: test
-  tags: 
-    - docker
-  image: ruby:2.2
-  allow_failure: true
-  script: 
-    - PUPPET_VERSION=4.7 bundle install
-    - PUPPET_VERSION=4.7 bundle exec rake spec
-unit-test-puppet4.7-ruby-2.3:
-  stage: test
-  tags: 
-    - docker
-  image: ruby:2.3
-  allow_failure: true
-  script: 
-    - PUPPET_VERSION=4.7 bundle install
-    - PUPPET_VERSION=4.7 bundle exec rake spec
+#=======================================================================
+# Global stuff
+stages:
+  - 'sanity'
+  - 'lint'
+  - 'unit'
+  - 'acceptance'
+  - 'deployment'
 
-acceptance-test: 
-  stage: test
-  tags: 
-    - beaker
-  script: 
-    - bundle install --no-binstubs --path=vendor
-    - bundle exec rake acceptance
+# Default versions are set only as fallbacks for jobs that don't care which
+# version they use.  Versions should be explicitly set in any job with specific
+# version requirements, even if they match these defaults.
+image: 'ruby:2.1'
+variables:
+  PUPPET_VERSION: '~> 4.10.0'
+  BUNDLER_VERSION: '1.16.1'
+  MODULE_NAME: "$(ruby -r json -e 'JSON.load(File.read('metadata.json'))['name']')"
+  MODULE_VERSION: "$(ruby -r json -e 'JSON.load(File.read('metadata.json'))['version']')"
+
+before_script:
+  - 'ruby -v'
+  - 'gem list -ie --silent -v "$BUNDLER_VERSION" bundler && bundle -v || gem install bundler --no-document -v "$BUNDLER_VERSION"'
+  - 'bundle install -j $(nproc) --no-binstubs --path vendor'
+
+cache:
+  key: '${CI_COMMIT_REF_SLUG}'
+  paths:
+    - 'vendor/ruby'
+
+#=======================================================================
+# Anchors
+
+.lint_base: &lint_base
+  stage: 'lint'
+  tags: ['docker']
+  script:
+    - 'bundle exec rake syntax'
+    - 'bundle exec rake lint'
+  cache:
+    policy: 'pull'
+  dependencies: []
+  artifacts:
+    when: 'always'
+    paths:
+      - 'Gemfile.lock'
+
+.unit_base: &unit_base
+  stage: 'unit'
+  tags: ['docker']
+  script:
+    - 'bundle exec rake spec'
+  cache:
+    policy: 'pull'
+  dependencies: []
+  artifacts:
+    when: 'always'
+    paths:
+      - 'Gemfile.lock'
+
+.acceptance_base: &acceptance_base
+  stage: 'acceptance'
+  tags: ['beaker']
+  cache:
+    policy: 'pull'
+  dependencies: []
+  artifacts:
+    when: 'always'
+    paths:
+      - 'Gemfile.lock'
+
+# ----------------------------------------------------------------------
+# Version Matrix
+#
+# It would be too expensive, both in time and compute resources, to test
+# against every last version combination, so we restrict it to this subset.
+# Version sets are selected based on current support policies for major platform
+# software, such as Puppet and Ruby.  Namely, we use the version combinations
+# bundled in Puppet Enterprise.
+#
+# For more information see:
+#  * https://puppet.com/docs/pe/latest/overview/component_versions_in_recent_pe_releases.html
+#  * https://puppet.com/misc/puppet-enterprise-lifecycle
+#  * https://puppet.com/docs/pe/latest/overview/getting_support_for_pe.html#standard-releases-and-long-term-support-releases
+#
+# ----------------------------------------------
+# | Release | Puppet | Ruby | End-of-Life Date |
+# ----------|--------|------|------------------|
+# PE 2016.4   4.7      2.1    2018-10
+# PE 2016.5   4.8      2.1    2017-05
+# SIMP 6.0    4.8      2.1    TBD
+# PE 2017.1   4.9      2.1    2017-10
+# PE 2017.2   4.10     2.1    2018-02
+# PE 2017.3   5.3      2.4    2018-08
+# PE 2018.1   5.5      2.4    2020-05
+#
+
+.pe_2016_4: &pe_2016_4
+  variables:
+    PUPPET_VERSION: '~> 4.10.0'
+    BEAKER_PUPPET_COLLECTION: 'pc1'
+    BEAKER_PUPPET_AGENT_VERSION: '~> 1.10.0'
+
+.pe_2016_5: &pe_2016_5
+  variables:
+    PUPPET_VERSION: '~> 4.8.1'
+    BEAKER_PUPPET_COLLECTION: 'pc1'
+    BEAKER_PUPPET_AGENT_VERSION: '~> 1.8.2'
+
+.simp_6: &simp_6
+  variables:
+    PUPPET_VERSION: '~> 4.8.1'
+    BEAKER_PUPPET_COLLECTION: 'pc1'
+    BEAKER_PUPPET_AGENT_VERSION: '~> 1.8.2'
+
+.pe_2017_1: &pe_2017_1
+  variables:
+    PUPPET_VERSION: '~> 4.9.4'
+    BEAKER_PUPPET_COLLECTION: 'pc1'
+    BEAKER_PUPPET_AGENT_VERSION: '~> 1.9.3'
+
+.pe_2017_2: &pe_2017_2
+  variables:
+    PUPPET_VERSION: '~> 4.10.1'
+    BEAKER_PUPPET_COLLECTION: 'pc1'
+    BEAKER_PUPPET_AGENT_VERSION: '~> 1.10.1'
+
+.pe_2017_3: &pe_2017_3
+  variables:
+    PUPPET_VERSION: '~> 5.3.2'
+    BEAKER_PUPPET_COLLECTION: 'puppet5'
+    BEAKER_PUPPET_AGENT_VERSION: '~> 5.3.2'
+
+.pe_2018_1: &pe_2018_1
+  variables:
+    PUPPET_VERSION: '~> 5.5.1'
+    BEAKER_PUPPET_COLLECTION: 'puppet5'
+    BEAKER_PUPPET_AGENT_VERSION: '~> 5.5.1'
+
+.pup_5_latest: &pup_5_latest
+  variables:
+    PUPPET_VERSION: '~> 5.0'
+    BEAKER_PUPPET_COLLECTION: 'puppet5'
+    BEAKER_PUPPET_AGENT_VERSION: '~> 5.0'
+
+
+#=======================================================================
+# Basic Sanity Checks
+#
+
+# Execute simple sanity checks on the environment before proceeding to more
+# resource-intensive jobs.  Besides running checks, this condenses the initial
+# cache generation into a single job for the later stages.  The first stage,
+# in particular, would otherwise suffer a heavy cache-miss penalty as its
+# jobs kick off in parallel.
+sanity_checks:
+  stage: 'sanity'
+  tags: ['docker']
+  script:
+    - 'bundle exec rake check:dot_underscore'
+    - 'bundle exec rake check:test_file'
+    - 'bundle exec rake pkg:check_version'
+    - 'bundle exec rake pkg:compare_latest_tag'
+
+tag_check:
+  stage: 'sanity'
+  only: ['tags']
+  tags: ['docker']
+  script: '[ "$CI_COMMIT_TAG" = "$MODULE_VERSION" ] || echo "ERROR: Tag does not match metadata version" && exit 1'
+
+
+#=======================================================================
+# Lint Tests
+#
+
+# Linting, for the most part, isn't affected by version changes in Puppet,
+# so we only test against the latest version for each MAJOR release.
+pup4_x-lint:
+  <<: *lint_base
+  image: 'ruby:2.1'
+  variables:
+    PUPPET_VERSION: '~> 4.0'
+
+pup5_x-lint:
+  <<: *lint_base
+  image: 'ruby:2.4'
+  variables:
+    PUPPET_VERSION: '~> 5.0'
+
+#=======================================================================
+# Unit Test Matrix
+#
+
+# ----------------------------------------------------------------------
+# Puppet 4.7 for PE 2016.4 LTS Support (EOL: 2018-10)
+pup4_7-unit:
+  <<: *unit_base
+  <<: *pe_2016_4
+  image: 'ruby:2.1'
+
+# ----------------------------------------------------------------------
+# Puppet 4.8 for SIMP 6 (EOL: TBD) and PE 2016.5 (EOL: 2017-04)
+pup4_8-unit:
+  <<: *unit_base
+  <<: *pe_2016_5
+  image: 'ruby:2.1'
+
+# ----------------------------------------------------------------------
+# Puppet 4.10 for PE 2017.2 support (EOL:2018-02)
+pup4_10-unit:
+  <<: *unit_base
+  <<: *pe_2017_2
+  image: 'ruby:2.1'
+
+# ----------------------------------------------------------------------
+# Puppet 5.3 for PE 2017.3 support (EOL: 2018-07)
+pup5_3-unit:
+  <<: *unit_base
+  <<: *pe_2017_3
+  image: 'ruby:2.4'
+
+# ----------------------------------------------------------------------
+# Puppet 5.5 for PE 2018.1 LTS support (EOL: 2020-05)
+pup5_5-unit:
+  <<: *unit_base
+  <<: *pe_2018_1
+  image: 'ruby:2.4'
+
+# ----------------------------------------------------------------------
+# Keep an eye on the latest Puppet 5.x release
+pup5_latest-unit:
+  <<: *unit_base
+  image: 'ruby:2.4'
+  variables:
+    PUPPET_VERSION: '~> 5.0'
+
+
+# ==============================================================================
+# Acceptance tests
+#
+
+# ----------------------------------------------------------------------
+# Puppet 4.8 for SIMP 6 (EOL: TBD) and PE 2016.5 (EOL: 2017-04)
+el-pup4_8-default:
+  <<: *acceptance_base
+  <<: *simp_6
+  script:
+    - 'bundle exec rake beaker:suites'
+
+el-pup4_8-default-fips:
+  <<: *acceptance_base
+  <<: *simp_6
+  variables:
+    BEAKER_fips: 'yes'
+  script:
+    - 'bundle exec rake beaker:suites'
+
+# ----------------------------------------------------------------------
+# Puppet 5.5 for PE 2018.1 LTS support (EOL: 2020-05)
+el-pup5_5-default:
+  <<: *acceptance_base
+  <<: *pe_2018_1
+  script:
+    - 'bundle exec rake beaker:suites'
+
+el-pup5_5-default-fips:
+  <<: *acceptance_base
+  <<: *pe_2018_1
+  variables:
+    BEAKER_fips: 'yes'
+  script:
+    - 'bundle exec rake beaker:suites'
+
+# vi:tabstop=2:shiftwidth=2:expandtab

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,48 +8,89 @@
 # PE 2017.2   4.10  2.1.9  TBD
 ---
 language: ruby
-sudo: false
 cache: bundler
-before_script:
-  - bundle update
+sudo: false
+
 bundler_args: --without development system_tests --path .vendor
-before_install: rm Gemfile.lock || true
-script:
-  - bundle exec rake test
+
 notifications:
   email: false
-rvm:
-  - 2.1.9
-env:
-  global:
-    - STRICT_VARIABLES=yes
-  matrix:
-    - PUPPET_VERSION="~> 4.8.2" FORGE_PUBLISH=true
-    - PUPPET_VERSION="~> 4.10.0"
-    - PUPPET_VERSION="~> 4.9.2"
-    - PUPPET_VERSION="~> 4.7.0"
-matrix:
-  fast_finish: true
 
-before_deploy:
-  - 'bundle exec rake metadata_lint'
-  - 'bundle exec rake clobber'
-  - 'bundle exec rake spec_clean'
-  - "export PUPMOD_METADATA_VERSION=`ruby -r json -e \"puts JSON.parse(File.read('metadata.json')).fetch('version')\"`"
-  - '[[ $TRAVIS_TAG =~ ^simp-${PUPMOD_METADATA_VERSION}$|^${PUPMOD_METADATA_VERSION}$ ]]'
-deploy:
-  - provider: puppetforge
-    user: simp
-    password:
-        secure: "d/Rv4hKx7BgvktVYdWRv3SGQcwzzxMH1rZBeel8GBt0FUyWr+dpOEA/DAEoivZ4vpu+7Kmd5rOJEQHmkR9uCb+HW2xFmuTUHlDLNAS7W1qoz6eE8GFGUe3NSDnX3xgzxri8d7BtYRsOu2jZzBLaO/I6EPYtZb907pwh6w1GA3LH1CnLm9YC16gTLd0NSEZu8YZoWT6w/lBpccOrhqeJWwr3uHxeYvzkyZbagTQdialpCP8h0nbk8kQbG4wO4CWeTOsSgtReEJKVXtW7A+DK1Ew/H+xCstpaXTkQyYxgX2G0Y5feSZNhAo3ptw+kA0AiP7E8GVXoTNVVs3Oip3qzmz63VUWcdcXC7HKW8853FOefS8lDXplfjiH9aJeGuzs/Vl67bgCT28gD57FxBsT/S6nS3Y3tQUmlTrwUVTT4wOosSaP7UaREQJ7NYTf3OZkhxQGeTyo7MZuAhp72zNCZpEEA6uTCIJZE4bQozxTF/gM2Y4jf8zllBbco7DylWGAs+7gy4PtpOStPVBci4VHFKbiZB4llWJLT3CD7okYi3/eCfBVWtCtPh5wBMiWqGBjXSUmMPyd2ZZBypl9ckvCujsykEi5KtaHEClXk+JcBncDEIV2E+yOsSPaiD/RxosyZQ5HoFBoWgQSV1OsNJSZqjOx5B+63f4xY7tG/7dsyKvZE="
-    on:
-      tags: true
+addons:
+  apt:
+    packages:
+      - rpm
+
+before_install:
+  - rm -f Gemfile.lock
+
+jobs:
+  allow_failures:
+    - env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 5.0"
+
+  include:
+    - stage: check
+      rvm: 2.4.1
+      script:
+        - bundle exec rake check:dot_underscore
+        - bundle exec rake check:test_file
+        - bundle exec rake lint
+        - bundle exec rake metadata_lint
+        - bundle exec rake pkg:check_version
+        - bundle exec rake pkg:compare_latest_tag
+        - bundle exec rake pkg:create_tag_changelog
+        - bundle exec puppet module build
+
+    - stage: spec
+      rvm: 2.4.1
+      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 5.0"
+      script:
+        - bundle exec rake spec
+
+    - stage: spec
       rvm: 2.1.9
-      condition: '($SKIP_FORGE_PUBLISH != true) && ($FORGE_PUBLISH = true)'
-  - provider: releases
-    api_key:
-        secure: "KukXhCs65X+UIhNbZWFvn2tQ8VC9qePYocIjpdMRJNIiy/FUPRo16Hs+kVa0NKVv+9/xY02iJitOcrLIbX/c4hp6vwatkAHx+akf5U1SrdAHtm6rvT5mYOmS7zUXEkMAkuZ6sczvq7fxvW0l1syyItiwt6rTCo+FO8GRm3b2Nx7ROTUriKagt7dxJzXyj3K6dfHhszH3gwZnBESAHMBThJt/1LoVCuKfHfx9VYq0S5ddsId936k1rcFiSxlGOeR5efKp1KCQ41CUUHJvfI6anKkrbsuNehelJhAa4nXcgaf1g8Lz8dxlxypDkFYTj1gcRsP6upfbqLEWLlrhHtoFT8c3xXO5/EF+MiN7KMEmy1uu+K8bf4VYQV23eHdarVJaraxwU4LBSdAC9/+R6V1sWFNkux5jcPvK3qZCYWaPWocmX7BRCNhthuHpnmWbAOxjgfwhif2FFAgxuXUBLC37dirn3pgy1k3i3Tr5Fdi4gq3gVhXJE2EHNHMbQjFfIdTBAOQmY/Sgo3Iw5OgKwoma7tspabo4vkzpFdLeOike92HmHUAgnX7CLB07/06wNMTWMfyiKBECK6CYcIIWIbwvE3sS5xwEr+8EE+7r6TNF0+eqObnw9nNmkUkEOw5lKAZuZjH+Gb1QX9XUN3pQTy7HPHGC8PZ3yNPRD5aUFmBv6Ow="
-    skip_cleanup: true
-    on:
-      tags: true
-      condition: '($SKIP_FORGE_PUBLISH != true) && ($FORGE_PUBLISH = true)'
+      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 4.10.0"
+      script:
+        - bundle exec rake spec
+
+    - stage: spec
+      rvm: 2.1.9
+      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 4.9.2"
+      script:
+        - bundle exec rake spec
+
+    - stage: spec
+      rvm: 2.1.9
+      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 4.8.2"
+      script:
+        - bundle exec rake spec
+
+    - stage: spec
+      rvm: 2.1.9
+      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 4.7.0"
+      script:
+        - bundle exec rake spec
+
+    - stage: deploy
+      rvm: 2.4.1
+      script:
+        - true
+      before_deploy:
+        - "export PUPMOD_METADATA_VERSION=`ruby -r json -e \"puts JSON.parse(File.read('metadata.json')).fetch('version')\"`"
+        - '[[ $TRAVIS_TAG =~ ^simp-${PUPMOD_METADATA_VERSION}$|^${PUPMOD_METADATA_VERSION}$ ]]'
+      deploy:
+        - provider: releases
+          api_key:
+            secure: "KukXhCs65X+UIhNbZWFvn2tQ8VC9qePYocIjpdMRJNIiy/FUPRo16Hs+kVa0NKVv+9/xY02iJitOcrLIbX/c4hp6vwatkAHx+akf5U1SrdAHtm6rvT5mYOmS7zUXEkMAkuZ6sczvq7fxvW0l1syyItiwt6rTCo+FO8GRm3b2Nx7ROTUriKagt7dxJzXyj3K6dfHhszH3gwZnBESAHMBThJt/1LoVCuKfHfx9VYq0S5ddsId936k1rcFiSxlGOeR5efKp1KCQ41CUUHJvfI6anKkrbsuNehelJhAa4nXcgaf1g8Lz8dxlxypDkFYTj1gcRsP6upfbqLEWLlrhHtoFT8c3xXO5/EF+MiN7KMEmy1uu+K8bf4VYQV23eHdarVJaraxwU4LBSdAC9/+R6V1sWFNkux5jcPvK3qZCYWaPWocmX7BRCNhthuHpnmWbAOxjgfwhif2FFAgxuXUBLC37dirn3pgy1k3i3Tr5Fdi4gq3gVhXJE2EHNHMbQjFfIdTBAOQmY/Sgo3Iw5OgKwoma7tspabo4vkzpFdLeOike92HmHUAgnX7CLB07/06wNMTWMfyiKBECK6CYcIIWIbwvE3sS5xwEr+8EE+7r6TNF0+eqObnw9nNmkUkEOw5lKAZuZjH+Gb1QX9XUN3pQTy7HPHGC8PZ3yNPRD5aUFmBv6Ow="
+          skip_cleanup: true
+          on:
+            tags: true
+            condition: '($SKIP_FORGE_PUBLISH != true)'
+        - provider: puppetforge
+          user: simp
+          password:
+            secure: "d/Rv4hKx7BgvktVYdWRv3SGQcwzzxMH1rZBeel8GBt0FUyWr+dpOEA/DAEoivZ4vpu+7Kmd5rOJEQHmkR9uCb+HW2xFmuTUHlDLNAS7W1qoz6eE8GFGUe3NSDnX3xgzxri8d7BtYRsOu2jZzBLaO/I6EPYtZb907pwh6w1GA3LH1CnLm9YC16gTLd0NSEZu8YZoWT6w/lBpccOrhqeJWwr3uHxeYvzkyZbagTQdialpCP8h0nbk8kQbG4wO4CWeTOsSgtReEJKVXtW7A+DK1Ew/H+xCstpaXTkQyYxgX2G0Y5feSZNhAo3ptw+kA0AiP7E8GVXoTNVVs3Oip3qzmz63VUWcdcXC7HKW8853FOefS8lDXplfjiH9aJeGuzs/Vl67bgCT28gD57FxBsT/S6nS3Y3tQUmlTrwUVTT4wOosSaP7UaREQJ7NYTf3OZkhxQGeTyo7MZuAhp72zNCZpEEA6uTCIJZE4bQozxTF/gM2Y4jf8zllBbco7DylWGAs+7gy4PtpOStPVBci4VHFKbiZB4llWJLT3CD7okYi3/eCfBVWtCtPh5wBMiWqGBjXSUmMPyd2ZZBypl9ckvCujsykEi5KtaHEClXk+JcBncDEIV2E+yOsSPaiD/RxosyZQ5HoFBoWgQSV1OsNJSZqjOx5B+63f4xY7tG/7dsyKvZE="
+          on:
+            tags: true
+            rvm: 2.4.1
+            condition: '($SKIP_FORGE_PUBLISH != true)'

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Mon Jun 25 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 0.0.3-0
+- Removed the static banners from the module and tied the module to the
+  `simp/simp_banners` module
+
 * Thu Jul 06 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 0.0.2-0
 - Update puppet dependency and remove OBE pe dependency in metadata.json
 

--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ group :test do
   gem 'puppet-lint-empty_string-check',   :require => false
   gem 'puppet-lint-trailing_comma-check', :require => false
   gem 'simp-rspec-puppet-facts', ENV.fetch('SIMP_RSPEC_PUPPET_FACTS_VERSION', '~> 2.0')
-  gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', '~> 4.0')
+  gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION',['>= 5.2', '< 6.0'])
 end
 
 group :development do
@@ -25,17 +25,12 @@ group :development do
   gem 'travis-lint'
   gem 'travish'
   gem 'puppet-blacksmith'
-  gem 'guard-rake'
   gem 'pry'
   gem 'pry-doc'
-
-  # `listen` is a dependency of `guard`
-  # from `listen` 3.1+, `ruby_dep` requires Ruby version >= 2.2.3, ~> 2.2
-  gem 'listen', '~> 3.0.6'
 end
 
 group :system_tests do
   gem 'beaker'
   gem 'beaker-rspec'
-  gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', '~> 1.7')
+  gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', '~> 1.10')
 end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,14 +5,21 @@
 #
 #   Will be overridden by `$content` and/or `$net_content`
 #
-#   Valid values include:
-#     * default     => Standard, we watch everything
-#     * lite        => We only watch for bad things
-#     * us_doc      => U.S. Department of Commerce
-#     * us_doc_lite => U.S. Department of Commerce lite
-#     * us_dod      => U.S. Department of Defense (STIG Compat)
-#     * us_noaa     => U.S. National Oceanic and Atmospehric
-#                      Administration
+#   Valid values are defined by the `simp_banners` module but the local module
+#   has the following mappings for legacy support
+#     * default      => Standard, we watch everything
+#       * New Option => 'simp'
+#     * lite         => We only watch for bad things
+#       * New Option => 'simp_lite'
+#     * us_doc       => U.S. Department of Commerce
+#       * New Option => 'us/department_of_commerce'
+#     * us_doc_lite  => U.S. Department of Commerce lite
+#       * New Option => 'us/department_of_commerce_lite'
+#     * us_dod       => U.S. Department of Defense (STIG Compat)
+#       * New Option => 'us/department_of_defense'
+#     * us_noaa      => U.S. National Oceanic and Atmospehric
+#                       Administration
+#       * New Option => 'us/national_oceanic_and_atmospheric_administration'
 #
 # @param content
 #   Defaults to a stock `/etc/issue` file in the module. Provide a custom
@@ -33,25 +40,26 @@ class issue (
   Boolean          $net_link    = true,
   Optional[String] $net_content = undef
 ) {
-  $_valid_profiles = [
-    'default',
-    'lite',
-    'us_doc',
-    'us_doc_lite',
-    'us_dod',
-    'us_noaa'
-  ]
+
+  # This is needed for backward compatibility
+  $_valid_profiles = {
+    'default'     => 'simp',
+    'lite'        => 'simp_lite',
+    'us_doc'      => 'us/department_of_commerce',
+    'us_doc_lite' => 'us/department_of_commerce_lite',
+    'us_dod'      => 'us/department_of_defense',
+    'us_noaa'     => 'us/national_oceanic_and_atmospheric_administration'
+  }
 
   if $content {
     $_content = $content
   }
   else {
-    if $profile in $_valid_profiles {
-      $_content = file("${module_name}/issue/${profile}")
+    if $profile in keys($_valid_profiles) {
+      $_content = simp_banners::fetch($_valid_profiles[$profile])
     }
     else {
-      $_valid_profile_string = join($_valid_profiles,', ')
-      fail("You must choose a valid profile ${_valid_profile_string}")
+      $_content = simp_banners::fetch($profile)
     }
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-issue",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "author": "SIMP Team",
   "summary": "A SIMP Puppet module for managing /etc/issue",
   "license": "Apache-2.0",
@@ -13,6 +13,10 @@
     "issue.net"
   ],
   "dependencies": [
+    {
+      "name": "simp/simp_banners",
+      "version_requirement": ">= 0.1.0 < 2.0.0"
+    },
     {
       "name": "simp/simplib",
       "version_requirement": ">= 3.1.0 < 4.0.0"
@@ -41,7 +45,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.7.0 < 5.0.0"
+      "version_requirement": ">= 4.7.0 < 6.0.0"
     }
   ],
   "data_provider": "hiera"

--- a/spec/classes/issue_spec.rb
+++ b/spec/classes/issue_spec.rb
@@ -1,90 +1,83 @@
 require 'spec_helper'
 
 describe 'issue', type: :class do
-  describe 'On Linux' do
-    let(:facts) do
-      {
-        kernel: 'Linux',
-        operatingsystem: 'TestOS',
-        osfamily: 'Debian',
-        memoryfree: '1 KB',
-        domain: 'testdomain'
-      }
-    end
-    context 'When nothing is specified' do
-      it do
-        should contain_File('/etc/issue').with(
-          ensure: 'file',
-          content: /ATTENTION/
-        )
-        should contain_File('/etc/issue.net').with(
-          ensure: 'file',
-          source: 'file:///etc/issue'
-        )
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      context 'When nothing is specified' do
+        it do
+          should contain_File('/etc/issue').with(
+            ensure: 'file',
+            content: /ATTENTION/
+          )
+          should contain_File('/etc/issue.net').with(
+            ensure: 'file',
+            source: 'file:///etc/issue'
+          )
+        end
       end
-    end
 
-    context 'When content is specified' do
-      let(:params) do
-        {
-          content: 'Hello!'
-        }
+      context 'When content is specified' do
+        let(:params) do
+          {
+            content: 'Hello!'
+          }
+        end
+        it do
+          should contain_File('/etc/issue').with(
+            ensure: 'file',
+            content: 'Hello!'
+          )
+        end
       end
-      it do
-        should contain_File('/etc/issue').with(
-          ensure: 'file',
-          content: 'Hello!'
-        )
-      end
-    end
 
-    context 'When net_link is true' do
-      let(:params) do
-        {
-          net_link: true
-        }
+      context 'When net_link is true' do
+        let(:params) do
+          {
+            net_link: true
+          }
+        end
+        it do
+          should contain_File('/etc/issue').with(
+            ensure: 'file',
+            content: /ATTENTION/
+          )
+          should contain_File('/etc/issue.net').with(
+            ensure: 'file',
+            source: 'file:///etc/issue'
+          )
+        end
       end
-      it do
-        should contain_File('/etc/issue').with(
-          ensure: 'file',
-          content: /ATTENTION/
-        )
-        should contain_File('/etc/issue.net').with(
-          ensure: 'file',
-          source: 'file:///etc/issue'
-        )
-      end
-    end
 
-    context 'When net_link is false and net_content is specified' do
-      let(:params) do
-        {
-          net_link: false,
-          net_content: 'Hello!'
-        }
+      context 'When net_link is false and net_content is specified' do
+        let(:params) do
+          {
+            net_link: false,
+            net_content: 'Hello!'
+          }
+        end
+        it do
+          should contain_File('/etc/issue').with(
+            ensure: 'file',
+            content: /ATTENTION/
+          )
+          should contain_File('/etc/issue.net').with(
+            ensure: 'file',
+            content: 'Hello!'
+          )
+        end
       end
-      it do
-        should contain_File('/etc/issue').with(
-          ensure: 'file',
-          content: /ATTENTION/
-        )
-        should contain_File('/etc/issue.net').with(
-          ensure: 'file',
-          content: 'Hello!'
-        )
-      end
-    end
 
-    context 'When net_link is false and net_content is not specified' do
-      let(:params) do
-        {
-          net_link: false
-        }
+      context 'When net_link is false and net_content is not specified' do
+        let(:params) do
+          {
+            net_link: false
+          }
+        end
+        it do
+          expect{ is_expected.to compile }.to raise_error(/needs to be provided/)
+        end
       end
-      it do
-        expect{ is_expected.to compile }.to raise_error(/needs to be provided/)
-      end
-    end
 
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,7 +31,6 @@ default_hiera_config =<<-EOM
   :datadir: "stub"
 :hierarchy:
   - "%{custom_hiera}"
-  - "%{spec_title}"
   - "%{module_name}"
   - "default"
 EOM
@@ -47,7 +46,7 @@ EOM
 # end
 #
 def set_environment(environment = :production)
-    RSpec.configure { |c| c.default_facts['environment'] = environment.to_s }
+  RSpec.configure { |c| c.default_facts['environment'] = environment.to_s }
 end
 
 # This can be used from inside your spec tests to load custom hieradata within
@@ -120,30 +119,15 @@ RSpec.configure do |c|
   end
 
   c.before(:each) do
-    @spec_global_env_temp = Dir.mktmpdir('simpspec')
-
     if defined?(environment)
       set_environment(environment)
-      FileUtils.mkdir_p(File.join(@spec_global_env_temp,environment.to_s))
     end
 
-    # ensure the user running these tests has an accessible environmentpath
-    Puppet[:environmentpath] = @spec_global_env_temp
-    Puppet[:user] = Etc.getpwuid(Process.uid).name
-    Puppet[:group] = Etc.getgrgid(Process.gid).name
-
-    # sanitize hieradata
     if defined?(hieradata)
       set_hieradata(hieradata.gsub(':','_'))
     elsif defined?(class_name)
       set_hieradata(class_name.gsub(':','_'))
     end
-  end
-
-  c.after(:each) do
-    # clean up the mocked environmentpath
-    FileUtils.rm_rf(@spec_global_env_temp)
-    @spec_global_env_temp = nil
   end
 end
 

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -12,6 +12,9 @@ unless ENV['BEAKER_provision'] == 'no'
     else
       install_puppet
     end
+    # Install git, it's a dependency for inspec profiles
+    # Found this when experiencing https://github.com/chef/inspec/issues/1270
+    install_package(host, 'git')
   end
 end
 
@@ -28,12 +31,20 @@ RSpec.configure do |c|
     begin
       # Install modules and dependencies from spec/fixtures/modules
       copy_fixture_modules_to( hosts )
+      begin
+        server = only_host_with_role(hosts, 'server')
+      rescue ArgumentError =>e
+        server = only_host_with_role(hosts, 'default')
+      end
 
       # Generate and install PKI certificates on each SUT
       Dir.mktmpdir do |cert_dir|
-        run_fake_pki_ca_on( default, hosts, cert_dir )
+        run_fake_pki_ca_on(server, hosts, cert_dir )
         hosts.each{ |sut| copy_pki_to( sut, cert_dir, '/etc/pki/simp-testing' )}
       end
+
+      # add PKI keys
+      copy_keydist_to(server)
     rescue StandardError, ScriptError => e
       if ENV['PRY']
         require 'pry'; binding.pry


### PR DESCRIPTION
Moved the banner information out of the module and into a separate
`simp_banners` module so that they can both be used by other modules as
well as being moved ahead without requiring additional version bumps to
unrelated modules.

SIMP-4738 #close