### PR TITLE
(SIMP-4423) Ability to set file source

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Tue Dec 11 2018 Adam Yohrling <adam.yohrling@onyxpoint.com> - 0.0.4-0
+- Add source parameter to be able to specify a file for use directly
+  within hiera data
+
 * Wed Nov 07 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 0.0.3-0
 - Update static assets
 - Update to onyxpoint OEL boxes in acceptance tests

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-issue",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "author": "SIMP Team",
   "summary": "A SIMP Puppet module for managing /etc/issue",
   "license": "Apache-2.0",

--- a/spec/classes/issue_spec.rb
+++ b/spec/classes/issue_spec.rb
@@ -49,6 +49,23 @@ describe 'issue', type: :class do
         end
       end
 
+      context 'When source is specified' do
+        let(:params) do
+          {
+            source: 'puppet:///modules/site/etc/issue'
+          }
+        end
+        it do
+          should contain_File('/etc/issue').only_with(
+            ensure: 'file',
+            mode: '0644',
+            owner: 'root',
+            group: 'root',
+            source: 'puppet:///modules/site/etc/issue'
+          )
+        end
+      end
+
       context 'When net_link is true' do
         let(:params) do
           {


### PR DESCRIPTION
This change allows users to set the `source` parameter allowing files
to be used. The `file` function could be used to set content, but not
from hiera data directly. This allows a setting from hiera.

SIMP-4423 #comment Add source parameter
SIMP-4423 #close